### PR TITLE
Forgotten return statement in stringifySemver()

### DIFF
--- a/semver-utils.js
+++ b/semver-utils.js
@@ -42,6 +42,7 @@
     if (obj.build) {
       str += '+' + obj.build;
     }
+    return str;
   }
 
   function parseSemverRange(str) {


### PR DESCRIPTION
The function stringifySemver() must return the generate string.
